### PR TITLE
fix: bg-grid-pattern CSS 통합 및 미사용 유틸리티 정리

### DIFF
--- a/.commit_message.txt
+++ b/.commit_message.txt
@@ -1,1 +1,1 @@
-♻️ refactor: 블로그 SEO 5개 페이지 데이터 추출 (constants/blog/) + 레거시 파일 삭제
+🧹 fix: bg-grid-pattern CSS 통합 — 미사용 bg-grid-black/white 유틸리티 및 grid-pattern.svg 삭제

--- a/app/brand/page.tsx
+++ b/app/brand/page.tsx
@@ -374,7 +374,7 @@ export default function BrandPage() {
         <section className="relative h-[60vh] flex flex-col items-center justify-center overflow-hidden bg-slate-950 text-white">
           {/* Background Gradients */}
           <div className="absolute top-0 left-0 w-full h-full bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-blue-900/40 via-slate-950 to-slate-950"></div>
-          <div className="absolute inset-0 bg-[url('/images/grid-pattern.svg')] opacity-[0.05]"></div>
+          <div className="absolute inset-0 bg-grid-pattern opacity-[0.05]"></div>
 
           <div className="relative z-10 text-center max-w-5xl mx-auto px-6">
             <FadeIn>

--- a/app/calculators/page.tsx
+++ b/app/calculators/page.tsx
@@ -332,7 +332,7 @@ export default function CalculatorsPage() {
 
           {/* 통계 및 성과 */}
           <div className="relative overflow-hidden bg-gradient-to-br from-blue-600 to-indigo-700 dark:bg-slate-950 rounded-3xl p-10 mb-24 text-white shadow-2xl">
-            <div className="absolute top-0 left-0 w-full h-full bg-[url('/images/grid-pattern.svg')] opacity-10"></div>
+            <div className="absolute top-0 left-0 w-full h-full bg-grid-pattern opacity-10"></div>
             <div className="absolute top-0 right-0 w-96 h-96 bg-blue-500/20 rounded-full blur-3xl"></div>
             <div className="absolute bottom-0 left-0 w-96 h-96 bg-purple-500/20 rounded-full blur-3xl"></div>
 

--- a/app/insights/page.tsx
+++ b/app/insights/page.tsx
@@ -296,7 +296,7 @@ export default function InsightsPage() {
         <section className="py-24 bg-slate-50 dark:bg-slate-900/50">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div className="relative overflow-hidden bg-white dark:bg-slate-800 rounded-3xl p-12 shadow-xl border border-slate-100 dark:border-slate-700">
-              <div className="absolute top-0 left-0 w-full h-full bg-[url('/images/grid-pattern.svg')] opacity-[0.03]"></div>
+              <div className="absolute top-0 left-0 w-full h-full bg-grid-pattern opacity-[0.03]"></div>
 
               <div className="relative z-10 grid grid-cols-2 md:grid-cols-4 gap-12">
                 <div className="text-center group">
@@ -379,7 +379,7 @@ export default function InsightsPage() {
 
         {/* Newsletter CTA */}
         <section className="py-24 bg-gradient-to-br from-slate-900 to-blue-900 relative">
-          <div className="absolute inset-0 bg-[url('/images/grid-pattern.svg')] opacity-10"></div>
+          <div className="absolute inset-0 bg-grid-pattern opacity-10"></div>
           <div className="absolute top-0 right-0 w-[600px] h-[600px] bg-blue-500/20 rounded-full blur-3xl"></div>
 
           <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center relative z-10">

--- a/app/program/page.tsx
+++ b/app/program/page.tsx
@@ -33,7 +33,7 @@ function HeroSection() {
     <section className="relative w-full min-h-[70vh] flex flex-col items-center justify-center bg-slate-950 text-white overflow-hidden pt-20">
       {/* Dynamic Background */}
       <div className="absolute top-0 left-0 w-full h-full bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-blue-900/40 via-slate-950 to-slate-950 z-0"></div>
-      <div className="absolute inset-0 bg-[url('/images/grid-pattern.svg')] opacity-[0.05] z-0"></div>
+      <div className="absolute inset-0 bg-grid-pattern opacity-[0.05] z-0"></div>
 
       <div className="relative z-10 text-center max-w-6xl mx-auto px-6">
         {/* Badge */}

--- a/app/solutions/[category]/[service]/page.tsx
+++ b/app/solutions/[category]/[service]/page.tsx
@@ -74,7 +74,7 @@ export default async function ServiceDetailPage({ params }: ServiceDetailPagePro
           <section className="relative min-h-[70vh] flex flex-col items-center justify-center overflow-hidden bg-slate-950 text-white pt-20 pb-20">
             {/* Dynamic Background */}
             <div className="absolute top-0 left-0 w-full h-full bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-blue-900/40 via-slate-950 to-slate-950 z-0"></div>
-            <div className="absolute inset-0 bg-[url('/images/grid-pattern.svg')] opacity-[0.05] z-0"></div>
+            <div className="absolute inset-0 bg-grid-pattern opacity-[0.05] z-0"></div>
 
             <div className="container mx-auto px-6 relative z-10">
               <div className="max-w-4xl mx-auto text-center">

--- a/components/about/about-page-content.tsx
+++ b/components/about/about-page-content.tsx
@@ -77,7 +77,7 @@ export default function AboutPageContent() {
         <section className="relative w-full min-h-[90vh] flex flex-col items-center justify-center overflow-hidden bg-slate-950 text-white pt-20">
           {/* Dynamic Background */}
           <div className="absolute top-0 left-0 w-full h-full bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-blue-900/40 via-slate-950 to-slate-950 z-0"></div>
-          <div className="absolute inset-0 bg-[url('/images/grid-pattern.svg')] opacity-[0.05] z-0"></div>
+          <div className="absolute inset-0 bg-grid-pattern opacity-[0.05] z-0"></div>
 
           <div className="relative z-10 text-center max-w-6xl mx-auto px-6">
             <FadeIn delay={0.2} direction="down">
@@ -175,7 +175,7 @@ export default function AboutPageContent() {
 
         {/* 통계 섹션 */}
         <section className="py-20 bg-slate-50 dark:bg-slate-900/50 relative overflow-hidden">
-          <div className="absolute inset-0 bg-[url('/images/grid-pattern.svg')] opacity-[0.03]"></div>
+          <div className="absolute inset-0 bg-grid-pattern opacity-[0.03]"></div>
           <div className="container mx-auto px-4 relative z-10">
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
               {[
@@ -436,7 +436,7 @@ export default function AboutPageContent() {
 
         {/* 컨설턴트 소개 섹션 */}
         <section className="py-24 bg-gradient-to-br from-blue-50 via-white to-slate-50 dark:from-slate-900 dark:via-slate-950 dark:to-slate-900 relative overflow-hidden">
-          <div className="absolute inset-0 bg-[url('/images/grid-pattern.svg')] opacity-[0.03]"></div>
+          <div className="absolute inset-0 bg-grid-pattern opacity-[0.03]"></div>
           <div className="container mx-auto px-4 relative z-10">
             <div className="text-center mb-16">
               <div className="inline-flex items-center justify-center p-2 bg-white dark:bg-slate-800 rounded-full mb-6 shadow-sm">

--- a/components/contact/contact-page-content.tsx
+++ b/components/contact/contact-page-content.tsx
@@ -85,7 +85,7 @@ export default function ContactPageContent() {
         <section className="relative w-full py-24 md:py-32 flex flex-col items-center justify-center overflow-hidden">
           {/* Background Elements */}
           <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[800px] h-[800px] bg-gradient-to-r from-blue-400/10 via-purple-400/10 to-emerald-400/10 rounded-full blur-3xl -z-10"></div>
-          <div className="absolute inset-0 bg-[url('/images/grid-pattern.svg')] opacity-[0.03] pointer-events-none"></div>
+          <div className="absolute inset-0 bg-grid-pattern opacity-[0.03] pointer-events-none"></div>
 
           <div className="relative z-10 text-center max-w-5xl mx-auto px-6">
             <div className="flex justify-center mb-8">
@@ -176,7 +176,7 @@ export default function ContactPageContent() {
 
         {/* 메인 컨텐츠: 연락처 및 폼 */}
         <section className="py-24 relative overflow-hidden">
-          <div className="absolute inset-0 bg-[url('/images/grid-pattern.svg')] opacity-[0.03] pointer-events-none"></div>
+          <div className="absolute inset-0 bg-grid-pattern opacity-[0.03] pointer-events-none"></div>
           <div className="container mx-auto px-4 relative z-10">
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 max-w-6xl mx-auto">
               {/* 좌측: 연락처 정보 */}

--- a/components/sections/hero-section.tsx
+++ b/components/sections/hero-section.tsx
@@ -13,7 +13,7 @@ export function HeroSection() {
     <div className="relative min-h-[90vh] flex flex-col items-center justify-center overflow-hidden bg-slate-950 text-white pt-20">
       {/* Dynamic Background */}
       <div className="absolute top-0 left-0 w-full h-full bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-blue-900/40 via-slate-950 to-slate-950 z-0"></div>
-      <div className="absolute inset-0 bg-[url('/images/grid-pattern.svg')] opacity-[0.05] z-0"></div>
+      <div className="absolute inset-0 bg-grid-pattern opacity-[0.05] z-0"></div>
 
       {/* Floating Elements */}
       <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-blue-600/10 rounded-full blur-[100px] animate-pulse z-0 hidden lg:block"></div>

--- a/components/sections/services-section.tsx
+++ b/components/sections/services-section.tsx
@@ -26,7 +26,7 @@ export function ServicesSection() {
       className="section bg-gradient-to-br from-slate-50 via-white to-slate-50 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 relative overflow-hidden"
     >
       {/* Background Elements */}
-      <div className="absolute top-0 left-0 w-full h-full bg-[url('/images/grid-pattern.svg')] opacity-[0.03] pointer-events-none"></div>
+      <div className="absolute top-0 left-0 w-full h-full bg-grid-pattern opacity-[0.03] pointer-events-none"></div>
       <div className="absolute top-1/4 right-0 w-[500px] h-[500px] bg-blue-400/5 rounded-full blur-3xl pointer-events-none"></div>
       <div className="absolute bottom-0 left-0 w-[500px] h-[500px] bg-purple-400/5 rounded-full blur-3xl pointer-events-none"></div>
 
@@ -90,7 +90,7 @@ export function ServicesSection() {
         {/* 통계 섹션 */}
         <FadeIn direction="up" delay={0.2}>
           <div className="relative rounded-3xl p-10 mb-20 overflow-hidden bg-slate-900 dark:bg-slate-950 text-white shadow-2xl">
-            <div className="absolute inset-0 bg-[url('/images/grid-pattern.svg')] opacity-10"></div>
+            <div className="absolute inset-0 bg-grid-pattern opacity-10"></div>
             <div className="absolute top-0 right-0 w-96 h-96 bg-blue-500/20 rounded-full blur-3xl"></div>
             <div className="absolute bottom-0 left-0 w-96 h-96 bg-purple-500/20 rounded-full blur-3xl"></div>
 

--- a/public/Images/grid-pattern.svg
+++ b/public/Images/grid-pattern.svg
@@ -1,8 +1,0 @@
-<svg width="100" height="100" xmlns="http://www.w3.org/2000/svg">
-  <defs>
-    <pattern id="grid" width="20" height="20" patternUnits="userSpaceOnUse">
-      <path d="M 20 0 L 0 0 0 20" fill="none" stroke="currentColor" stroke-width="0.5" opacity="0.3"/>
-    </pattern>
-  </defs>
-  <rect width="100" height="100" fill="url(#grid)" />
-</svg>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -292,20 +292,7 @@ const config: Config = {
       },
     },
   },
-  plugins: [
-    require('tailwindcss-animate'),
-    // Grid background utility
-    function ({ addUtilities }: any) {
-      addUtilities({
-        '.bg-grid-black': {
-          'background-image': `url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 60 60' width='60' height='60'%3e%3cdefs%3e%3cpattern id='grid' width='60' height='60' patternUnits='userSpaceOnUse'%3e%3cpath d='M 60 0 L 0 0 0 60' fill='none' stroke='%23000000' stroke-width='1' opacity='0.1'/%3e%3c/pattern%3e%3c/defs%3e%3crect width='100%25' height='100%25' fill='url(%23grid)' /%3e%3c/svg%3e")`,
-        },
-        '.bg-grid-white': {
-          'background-image': `url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 60 60' width='60' height='60'%3e%3cdefs%3e%3cpattern id='grid' width='60' height='60' patternUnits='userSpaceOnUse'%3e%3cpath d='M 60 0 L 0 0 0 60' fill='none' stroke='%23ffffff' stroke-width='1' opacity='0.1'/%3e%3c/pattern%3e%3c/defs%3e%3crect width='100%25' height='100%25' fill='url(%23grid)' /%3e%3c/svg%3e")`,
-        },
-      });
-    },
-  ],
+  plugins: [require('tailwindcss-animate')],
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- 9개 파일의 인라인 `bg-[url('/images/grid-pattern.svg')]` → `bg-grid-pattern` CSS 클래스로 통합
- `tailwind.config.ts`에서 미사용 `bg-grid-black`/`bg-grid-white` 유틸리티 삭제
- 불필요한 `public/images/grid-pattern.svg` 파일 삭제

## Why
grid 배경 패턴이 3가지 방식(인라인 SVG URL, Tailwind 플러그인, CSS 클래스)으로 혼재되어 있었음.
`globals.css`의 `.bg-grid-pattern` 클래스(linear-gradient 기반)로 일원화하여 유지보수성 향상.

## Changed Files
- `app/brand/page.tsx`, `app/calculators/page.tsx`, `app/insights/page.tsx`
- `app/program/page.tsx`, `app/solutions/[category]/[service]/page.tsx`
- `components/about/about-page-content.tsx`, `components/contact/contact-page-content.tsx`
- `components/sections/hero-section.tsx`, `components/sections/services-section.tsx`
- `tailwind.config.ts`, `public/images/grid-pattern.svg` (deleted)

## Test plan
- [x] TypeScript 타입 체크 통과
- [x] ESLint 통과
- [x] 프로덕션 빌드 성공 (139 페이지)
- [ ] 각 페이지의 grid 배경 패턴 시각적 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 사이트 전역에서 사용되는 그리드 패턴 배경 스타일링을 통합하여 코드 일관성 및 유지보수성 향상

* **정리**
  * 사용되지 않는 배경 유틸리티 클래스 제거로 코드베이스 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->